### PR TITLE
Update interview task to Buy Crypto flow with chart and Claude rules

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,82 @@
+Review the current staged changes (run `git diff --cached`). If nothing is staged, review all uncommitted changes (`git diff`) and stage everything before committing.
+
+Analyze the changes and generate a commit message following the **Conventional Commits 1.0.0** specification (https://www.conventionalcommits.org/en/v1.0.0/).
+
+**User-provided description:** $ARGUMENTS
+
+If the user provided a description above, use it as the `<description>` portion of the title line verbatim (just ensure it's lowercase and has no trailing period). You still determine the `<type>` and `<scope>` from the diff. If no description was provided, generate one from the diff as usual.
+
+## Commit message format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Rules
+
+### Scope strategy
+
+Determine whether to include a scope by inspecting the repository:
+
+1. **Check the repo name** (`basename $(git rev-parse --show-toplevel)`)
+2. If the repo name already represents a specific service or domain (e.g. `auth-service`, `transfers-api`, `payments-worker`, `kyc-service`), **omit the scope** — the repo is the scope:
+   ```
+   fix: prevent duplicate SEPA credits under concurrent requests
+   ```
+3. If the repo is broad or multi-module (e.g. `app-ios`, `backend-monolith`, `infrastructure`, `shared-libs`), **include a scope** targeting the module, feature area, or package affected:
+   ```
+   fix(payments): prevent duplicate SEPA credits under concurrent requests
+   ```
+4. When in doubt, include the scope — redundancy is a smaller sin than ambiguity.
+
+### Title line
+- **type** (REQUIRED): one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- **scope** (CONTEXTUAL): see scope strategy above
+- **`!`** after type/scope if the change is a BREAKING CHANGE, e.g. `feat(api)!: ...` or `feat!: ...`
+- **description** (REQUIRED): imperative mood, lowercase, no period at the end, max 72 characters total for the title line
+  - ✅ "add webhook handler for reverification"
+  - ❌ "Added webhook handler for reverification."
+
+### Body (include if changes are non-trivial)
+- Separate from title with one blank line
+- Explain **what** changed and **why**, not how
+- Wrap lines at 72 characters
+- May use multiple paragraphs separated by blank lines
+
+### Footer (include when applicable)
+- Separate from body with one blank line
+- Use `BREAKING CHANGE: <description>` for breaking changes (MUST be uppercase)
+- Use git trailer format for references: `Refs: #123`, `Closes: #456`
+- Multi-word tokens use `-` instead of spaces: `Reviewed-by:`, `Acked-by:`
+
+## Choosing the type
+
+| Type       | When to use                                                  | SemVer  |
+|------------|--------------------------------------------------------------|---------|
+| `feat`     | A new feature or capability for the user                     | MINOR   |
+| `fix`      | A bug fix                                                    | PATCH   |
+| `docs`     | Documentation only changes                                   | -       |
+| `style`    | Formatting, semicolons, whitespace (no logic change)         | -       |
+| `refactor` | Code restructuring that neither fixes a bug nor adds feature | -       |
+| `perf`     | Performance improvement                                      | PATCH   |
+| `test`     | Adding or updating tests                                     | -       |
+| `build`    | Build system or external dependencies (gradle, docker)       | -       |
+| `ci`       | CI/CD configuration (GitHub Actions, pipelines)              | -       |
+| `chore`    | Maintenance tasks that don't modify src or test files         | -       |
+| `revert`   | Reverting a previous commit                                  | -       |
+
+## Process
+
+1. Read the diff carefully
+2. Check the repo name to decide the scope strategy
+3. Determine the single most appropriate type
+4. If scope is needed, identify it from the primary module/package affected
+5. Write a concise imperative description
+6. If the change is non-trivial, write a body explaining what and why
+7. Add footers if there are breaking changes or issue references
+8. If changes span multiple unrelated concerns, suggest splitting into separate commits instead
+9. Run `git commit -m "<message>"` with the generated message

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,109 @@
+# Architecture Components and Patterns Overview: deblock
+
+This document outlines the key architectural components and design patterns preferred. Understanding these components and patterns is crucial for comprehending the codebase, facilitating development, and ensuring consistent pull request reviews.
+
+The project primarily adheres to a Clean Architecture philosophy, leveraging a multi-module structure to enforce separation of concerns. This typically involves distinct layers for UI, Domain, and Data, with clear unidirectional dependencies.
+
+## 1. UI Layer (Presentation Layer)
+
+This layer is responsible for displaying information to the user and handling user interactions.
+
+*   **Screens/Activities/Fragments/Composeables**: These are the visual components that users interact with. Specifically, `*Screen.kt` files typically contain the route definition for navigation and the root composable UI elements for a particular screen. They are passive observers of `ViewModel` states and dispatch user events back to the `ViewModel`.
+*   **ViewModels**: Act as a state holder and event processor for the UI. They hold and manage UI-related data in a lifecycle-conscious way, exposing `StateFlow` or `LiveData` to the UI. `*ViewModel.kt` files contain the presentation logic, transforming data from the Domain Layer into UI-consumable states and handling UI-specific actions. They receive necessary dependencies via constructor injection.
+
+### Common Patterns in UI Layer:
+*   **MVVM (Model-View-ViewModel)**: The primary architectural pattern for UI.
+    *   **View (Screens/Composeables)**: Observes `ViewModel` state, renders UI, and sends user events to the `ViewModel`.
+    *   **ViewModel**: Exposes UI state (often via `StateFlow` for Compose or `LiveData` for Fragments/Activities) and handles UI-related logic, delegating business logic to Use Cases in the Domain Layer. It survives configuration changes.
+    *   **FlowViewModel Pattern**: For multi-screen flows (e.g., transfers, top-up, onboarding), a combination of ViewModels is used:
+        *   **Flow ViewModel** (e.g., `FiatTransferFlowViewModel`, `CardTopUpViewModel`): A shared ViewModel scoped to the entire navigation flow using `viewModelScopedTo()`. It orchestrates the flow, maintains shared state across screens (e.g., selected currency, amount, transaction details), and provides common logic and dependencies. This ViewModel survives navigation between screens within the flow.
+        *   **Screen ViewModels** (e.g., `TransfersAssetSelectorViewModel`, `CreateStandingOrderViewModel`): Individual ViewModels for each sub-screen within the flow. They receive the Flow ViewModel as an `@Assisted` dependency through their constructor, allowing them to access shared state and delegate flow-level operations. Screen ViewModels handle screen-specific UI logic while the Flow ViewModel manages cross-screen concerns.
+*   **Unidirectional Data Flow (UDF)**: UI events flow upwards to the ViewModel, and UI state flows downwards from the ViewModel to the UI, ensuring predictable state management.
+*   **UI State Data Classes**: Dedicated immutable data classes are used to represent the entire UI state for a screen, promoting clarity and ease of testing.
+    *   **`*State.kt`**: Files named `[FeatureName]ScreenState.kt` (e.g., `CardsScreenState.kt`) define the full presentation state for a screen, encompassing all dynamic data required to render the UI.
+    *   **`*UiModel.kt`**: Files named `[FeatureName]UiModel.kt` (e.g., `CardItemUiModel.kt`) represent static UI elements or smaller, reusable data structures that are part of the overall screen state, often representing how domain models are presented in the UI.
+*   **Package Structure**: UI components typically reside in `ui` packages within feature modules (e.g., `feature/cards/ui/screens`, `feature/cards/ui/sensitiveinfo`).
+*   **Naming Conventions**: `ViewModel` classes follow a `[FeatureName]ViewModel.kt` naming convention. `*Screen.kt` for UI entry points, `*ScreenState.kt` for dynamic UI state, and `*UiModel.kt` for static UI element representation.
+
+## 2. Domain Layer (Business Logic Layer)
+
+This layer contains the core business rules and logic of the application. It is independent of any specific UI, database, or third-party library, making it highly reusable and testable.
+
+*   **Use Cases / Interactors**: These classes encapsulate specific business operations or workflows. They orchestrate interactions between the UI Layer (via ViewModels) and the Data Layer (via Repositories), applying business rules and transforming data into domain models.
+*   **Domain Models**: Plain Kotlin classes that represent the entities and value objects central to the business logic. They are free from any Android-specific dependencies, ensuring the domain layer's purity.
+
+### Common Patterns in Domain Layer:
+*   **Use Case Pattern**: Each Use Case (or Interactor) represents a single, specific business operation. This promotes the Single Responsibility Principle, making the business logic modular and testable in isolation. They are typically invoked by ViewModels.
+*   **Repository Interface Definition**: Repository interfaces, defining contracts for data access, are declared in the Domain Layer. This enforces the dependency inversion principle, allowing the Domain Layer to be independent of data implementation details.
+*   **Pure Kotlin Models**: Domain models are designed as pure Kotlin data classes, free of any Android framework dependencies.
+*   **Package Structure**: Domain modules (e.g., `:shared:CardsDomain`, `:libraries:CoreDomain`) contain use cases and domain models (`domain/model` package).
+*   **Naming Conventions**: Use Cases are typically named `[Action]UseCase.kt` or `[Action]Interactor.kt`.
+
+## 3. Data Layer
+
+This layer is responsible for retrieving, storing, and managing application data. It abstracts the specifics of data sources from the Domain Layer, providing a clean API for data access.
+
+*   **Repositories**: Implement the repository interfaces defined in the Domain Layer. They are responsible for coordinating data operations from various data sources (network, database, preferences) and resolving data conflicts. They map data models from data sources to domain models.
+*   **Data Sources**: Implement the actual mechanisms for fetching and storing data from specific sources. Examples include `RemoteDataSource` for network APIs, `LocalDataSource` for databases (e.g., Room) or shared preferences.
+*   **Data Models**: Data classes often used for network responses (DTOs) or database entities, which are then mapped to Domain Models by the Repositories.
+
+### Common Patterns in Data Layer:
+*   **Repository Pattern**: Provides an abstraction layer over data sources. The Domain Layer interacts solely with repository interfaces, unaware of the underlying data retrieval mechanisms.
+*   **Data Source Pattern**: Specific implementations for fetching data from distinct sources (e.g., `[FeatureName]RemoteDataSource`, `[FeatureName]LocalDataSource`).
+*   **Data Mapping**: Repositories or dedicated mapper classes are responsible for converting `Data Models` (network responses, database entities) into `Domain Models` and vice-versa, ensuring the Domain Layer remains clean.
+*   **Package Structure**: Data modules (e.g., `:shared:CardsData`, `:libraries:Network`, `:libraries:Database`) contain repositories and data sources. Data models are typically found in `data/model`, `data/remote/response`, or `data/local/entity` packages.
+*   **Naming Conventions**: Repository implementations reside in the Data Layer (e.g., `[FeatureName]RepositoryImpl.kt`).
+
+## 4. Dependency Injection
+
+The project utilizes a dependency injection framework to manage and provide dependencies throughout the application, promoting testability, modularity, and maintainability.
+
+*   **Hilt**: The primary dependency injection library, built on top of Dagger, providing Android-specific integrations and simplified setup.
+
+### Dependency Injection Patterns:
+*   **Hilt Modules (`@Module`, `@InstallIn`)**: Files named `*Module.kt` (e.g., `NetworkModule.kt`, `RepositoryModule.kt`) represent the main elements for defining how dependencies are provided. These modules contain `@Provides` or `@Binds` functions that instruct Hilt on how to create and provision instances of various components (e.g., network clients, database DAOs, repository implementations, use cases).
+*   **Constructor Injection**: The preferred method for providing dependencies, making classes easy to test and clearly defining their requirements. Dependencies are injected directly into the class constructors using `@Inject`.
+*   **Entry Points (`@EntryPoint`)**: Used for dependencies that cannot be constructor-injected (e.g., field injection in Activities/Fragments that Hilt doesn't directly support via `@AndroidEntryPoint`, or injecting into classes not owned by Hilt).
+*   **Scope Management**: Hilt annotations like `@Singleton`, `@ActivityScoped`, `@ViewModelScoped` are used to manage the lifecycle and scope of dependencies.
+
+## 5. Navigation
+
+Navigation within the application is handled using a dedicated component for a consistent and robust user experience.
+
+*   **Jetpack Navigation Component**: Used for managing in-app navigation, defining navigation graphs, and handling transitions between destinations (Composables, Fragments, Activities).
+*   **MainNavigator**: The central navigation component that serves as the main router and orchestrates the entire navigation structure. It contains:
+    *   **NavHost**: The main navigation host with a router screen as the entry point that determines the initial destination based on app state (Dashboard, Onboarding, etc.).
+    *   **All Feature Navigation Graphs**: Aggregates and registers all feature-specific navigation graphs for the entire project, including `landingGraph`, `walletGraph`, `transfersGraph`, `cardsGraph`, `profileGraph`, `onboardingGraph`, and many others. Each graph is registered by calling its respective graph function (e.g., `transfersGraph(appState.navController)`, `topUpGraph(appState.navController)`).
+    *   **Bottom Sheet Integration**: Wraps the NavHost with `ModalBottomSheetLayout` to support bottom sheet navigation across the app.
+
+### Navigation Patterns:
+*   **Feature Navigation Graphs (`*NavGraph.kt`)**: Each feature module typically contains one or more `*NavGraph.kt` files (e.g., `CardsNavGraph.kt`, `TransfersNavGraph.kt`, `RecoverWalletNavGraph.kt`). These files describe a logical flow of screens within a feature, defining the navigation routes, nested graphs, and associated composables. These individual feature graphs are then aggregated and registered in the MainNavigator.
+*   **Navigation Extension Functions (`*Navigation.kt` or `*NavigationExt.kt`)**: Files such as `[FeatureName]Navigation.kt` or `[FeatureName]NavigationExt.kt` provide extension functions on `NavController` (e.g., `NavController.navigateToCardsList()`, `NavController.navigateToTransfersGraph()`) to perform navigation actions in a type-safe and consistent manner. These extension functions are then used within the `*NavGraph.kt` files or directly by UI components to trigger navigation.
+*   **Composable-based Navigation**: For Jetpack Compose screens, navigation is handled using composable functions and a `NavController`, with routes defined as sealed classes or objects.
+*   **Arguments Passing**: Safe Args for Fragments/Activities and type-safe arguments for Compose are used to pass data between navigation destinations.
+*   **Package Structure**: Navigation-related logic and routes are often defined in `navigation` packages within feature modules (e.g., `:features:Cards/navigation`).
+*   **Naming Conventions**: `*NavGraph.kt` for navigation graph definitions, and `*Navigation.kt` or `*NavigationExt.kt` for `NavController` extension functions.
+
+## 6. Testing
+
+The project emphasizes comprehensive testing across different layers, employing various testing patterns and frameworks to ensure quality and reliability.
+
+*   **Unit Tests**: Focus on testing individual components (e.g., Use Cases, ViewModels, Repository implementations) in isolation from the Android framework or external dependencies.
+*   **Integration Tests**: Verify the interaction between multiple components or layers (e.g., a ViewModel and its Use Cases, or a Repository and its Data Sources).
+*   **UI Tests (Instrumentation Tests)**: Test the user interface and user flows on an Android device or emulator, simulating user interactions.
+
+### Testing Patterns:
+*   **Test Doubles (Mocks, Fakes, Stubs)**: Widely used to isolate components under test by replacing their dependencies with controlled versions.
+    *   **Mockk/Mockito**: Used for creating mock objects and verifying interactions.
+*   **Given-When-Then Structure**: A common pattern for organizing test cases, clearly separating setup (Given), action (When), and assertion (Then).
+*   **Faking Data at Repository Layer**: For integration and UI tests, repository implementations are often replaced with "fake" implementations that return predefined test data instead of interacting with actual network or database sources. This is achieved through Hilt's testing capabilities, where test-specific `@Module`s are provided to override the production bindings for repository interfaces with their fake implementations. This ensures fast, deterministic, and isolated testing of higher layers without external dependencies.
+*   **Coroutines Test Dispatchers**: For testing coroutine-based code, `TestCoroutineDispatcher` or `StandardTestDispatcher` are used to control the execution of coroutines and ensure determinism.
+*   **AndroidX Test Libraries**:
+    *   **Espresso**: For UI testing of individual activities or fragments.
+    *   **UI Automator**: For cross-app functional UI testing.
+*   **Robolectric**: Used for running Android unit tests on the JVM without needing an emulator or device, speeding up feedback cycles.
+*   **Package Structure**: 
+    *   **Unit Tests**: Located in `src/test/kotlin` within each module, mirroring the package structure of the code they are testing.
+*   **Naming Conventions**: Test files often append `Test` to the class name (e.g., `ViewModelTest.kt`, `RepositoryImplTest.kt`).
+
+---

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,52 @@
+## Workflow Orchestration
+
+### 1. Plan Node Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One tack per subagent for focused execution
+
+### 3. Self-Improvement Loop
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items
+2. **Verify Plan**: Check in before starting implementation
+3. **Track Progress**: Mark items complete as you go
+4. **Explain Changes**: High-level summary at each step
+5. **Document Results**: Add review section to `tasks/todo.md`
+6. **Capture Lessons**: Update `tasks/lessons.md` after corrections
+
+## Core Principles
+
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Android Home Task
 
-1. Create a new private repo and invite: @mario-deblock.
-2. Start or upload your project.
-3. We take into account:
-- UI only using Compose
+Create a new private repo and invite: @mario-deblock.
+
+## AI-Assisted Development
+
+At Deblock we value effective use of AI tooling. For this task, we encourage you to use **Claude Code** (or any AI assistant) as part of your workflow.
+We provide the folder `.claude/` with useful ready made assets, but you can translate those into codex or gemini too.
+
+**What we score:**
+- We will review your **git history** to assess progress and workflow. We score descriptive commits that reflect meaningful, incremental pieces of work. Bonus if we see the provided `/commit` under `.claude/commands` (or one of your own) used as you progress through the implementation. The commit history shows your structure when building a feature, and we pay attention to it.
+- We have included a `.claude/rules/architecture.md` file in this repo describing the architecture and coding standards we follow at Deblock. You can feed this to your AI assistant for context, or simply use it as a manual reference: what matters is the outcome.
+- We score positively if the architecture described in that file is followed.
+- See `.claude/rules` files.
+- We pay the most attention to the graph.
+
+## Tech Stack
+
+- UI using Compose
 - Single Activity with Compose - Navigation (no fragments) MVVM
 - Dependency injection with Dagger or Hilt
 - Repository pattern
@@ -19,79 +32,116 @@ Some easy steps to kick start your project:
 5. Networking with Retrofit
 6. Jetpack libs
 
+---
+
 ## Requirements
 
 ### Design
-![Screenshot 2023-09-01 at 14 34 54](https://github.com/deblock-hq/ios-interview/assets/115789674/2fc24d37-9fd3-4725-bde3-d55cbe6aa9ad)
+<img width="1185" height="814" alt="Screens" src="https://github.com/user-attachments/assets/a2f9c31c-38d0-4e56-856b-c162bfa6ff55" />
 
-[Figma file to follow colors, spacing, icons, etc here]([https://www.figma.com/file/SaT9UfRVHwrcpCN8p1kVKl/Test-project?type=design&node-id=0%3A1&mode=design&t=gS6wgz3FuWBBJfqV-1](https://www.figma.com/file/VT93Wn2koJjJpX38iZuVaL/Dev-Interview-Area?type=design&node-id=0%3A1&mode=design&t=S9xrmHEP2HpdbZds-1)
+🎨 => [Figma file to follow colors, spacing, icons, etc here](https://www.figma.com/design/62KFvBRvs44chtjkW43z0D/iOS-tests---Mar-2026?node-id=0-1&t=yXjfpNi5UNdPllu0-1)
 
 ### Features
-A Deblock user has a crypto wallet. This crypto wallet contains ETH.
-Assume the current user has a wallet balance of 10 ETH.
 
-In this screen:
-- As a user I can send ETH and select the amount without exceeding the wallet balance.
-- As a user I can select a currency to display the equivalent amount in EUR, USD or GBP from a modal with these fixed options.
-- As a user I can also switch the primary label of the component to be ETH or the selected currency (this will change the label displayed on the Send button too). As I type in this label an amount, it should convert the equivalent ETH<>FIAT
-- As a user I can see the estimated network fees in ETH.
+A Deblock user has a crypto wallet containing multiple assets (e.g. ETH, BTC, USDT).
+Assume the current user has the following balances:
+- **ETH**: 0.051
+- **BTC**: 0.051
+- **USDT**: 230
+
+The task consists of a **Buy Crypto flow** with two steps: **Set Amount** and **Set Limit**.
+
+---
+
+#### Step 1 — Set Amount
+
+**Screen: "Set amount"** — _subtitle: "Your {asset} purchase"_ (e.g. "Your BTC purchase")
+
+- The subtitle dynamically reflects the currently selected asset (e.g. selecting ETH changes it to "Your ETH purchase").
+- As a user I see a numeric input field to enter the amount I want to spend in fiat (e.g. EUR).
+- As a user I can select which crypto asset to buy by tapping a dropdown (e.g. "BTC"). This opens a **"Choose asset" modal**.
+- The **"Choose asset" modal** displays a list of available assets with their current balances (e.g. ETH 0.051, BTC 0.051, USDT 230). Each currency shows the current conversion to EUR value below the amount. See `Data points` section to obtain values from a free API.
+- A custom numeric keypad is displayed at the bottom for amount entry.
+- The **"Next"** button is disabled when the amount is 0 or empty, and becomes enabled once a valid amount is entered (e.g. €50).
+- Tapping "Next" navigates to the **Set Limit** screen.
+
+---
+
+#### Step 2 — Set Limit
+
+**Screen: "Set limit"** — _subtitle: "Current Price: € {currentPrice}"_
+
+- As a user I see the current market price of the selected asset displayed in the subtitle (e.g. "Current Price: € 1,460").
+- As a user I see a fiat input field to set my desired limit price (the price at which I want to buy).
+- Below the input, a helper text reads: _"is the price you will buy at"_.
+- A **price chart** is displayed showing recent price history for the selected asset.
+- The chart includes a **draggable horizontal line** (slider) that allows the user to visually set the limit price. Dragging the slider updates the input field and vice versa.
+- When a limit price is set, a percentage badge is shown indicating the difference from the current price (e.g. "+0.86%").
+- The **"Confirm {amount} limit"** button at the bottom reflects the entered limit price (e.g. "Confirm 1,200 limit"). It is disabled when the limit is 0 and enabled once a valid limit price is entered.
+
+---
+
+#### Step 3 — Order Summary
+
+**Screen: Order summary**
+
+- After confirming the limit, the user is taken to a summary screen.
+- The screen displays the purchase amount from Step 1 (e.g. 50 €) and the limit price from Step 2 (e.g. 1,200 €).
+- Additional order details are listed (asset, amounts, limit price).
+- This screen serves as a final review before the user confirms the order.
+
+---
+
+### Data Points
 
 You will need to consume 2 data points:
-1. Exchange rate (ETH to eur/gbp/usd)
-2. Estimated network fees
+1. Exchange rate (crypto to EUR)
+2. Price chart data
 
-#### 1. Obtaining Exchange rate
+#### 1. Obtaining Exchange Rate
 
-For the exchange rate, you can consume any free API, but here you have a working example you can use:
+For the exchange rate, you can consume any free API. Here is a working example:
 
 **Request**
 ```
-https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd
+https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=eur
 ```
 
 **Response**
 ```
 {
-  "ethereum": {
-    "usd": 1644.1
+  "bitcoin": {
+    "eur": 1460.0
   }
 }
 ```
 
-`vs_currencies` accepts `usd`, `eur` and `gbp` so you will be covered for this task :)
+You can replace `bitcoin` with `ethereum` and `vs_currencies` accepts `usd`, `eur` and `gbp`.
 
-#### 2. Estimated Network Fees
+#### 2. Price Chart Data
 
-For the ETH Network fees, you can use the following formula + API to obtain the data
-
-**Formula**
-```
-Est Network fees = 21000 * {gasPrice} / 100000000
-```
-
-To obtain the current `{gasPrice}`:
+For the price chart, you can use a free API to obtain historical price data. Here is a working example:
 
 **Request**
 ```
-https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=YourApiKeyToken
+https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=eur&days=30
 ```
-_If you dont have an apiToken you have a rate limit of 1/5 seconds._
 
 **Response**
 ```
-{"status":"1","message":"OK-Missing/Invalid API Key, rate limit of 1/5sec applied","result":{"LastBlock":"18041185","SafeGasPrice":"13","ProposeGasPrice":"14","FastGasPrice":"14","suggestBaseFee":"12.086368893","gasUsedRatio":"0.505199894363513,0.45067015395881,0.364857033333333,0.700552333333333,0.461159333333333"}}
+{
+  "prices": [
+    [1648684800000, 1420.5],
+    [1648771200000, 1435.2],
+    ...
+  ]
+}
 ```
 
-Extract and use the `FastGasPrice` param.
-
-So the estimated gas fee to be displayed is equal to
-```
-21000 * {FastGasPrice} / 100000000
-```
-
+Each entry is a `[timestamp, price]` pair.
 
 ## What we look for
 - Be pixel perfect
-- Animate the modal
 - Clean code (networking, UI, simplicity)
-- BE FAST EXECUTING.
+- Interactive chart with draggable limit line
+- Use of AI, without the AI slop :)


### PR DESCRIPTION
Replace the old ETH send screen task with a multi-step Buy Crypto flow (Set Amount, Set Limit with interactive chart, Order Summary). Add .claude/ directory with architecture rules, workflow guidelines, and custom commit command. Update data points to use CoinGecko chart API and refresh scoring criteria to emphasize AI-assisted development.